### PR TITLE
fix: moving the contribution to new sub heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > You might experience some delay or issue with the API's, we are working on it. If you want to contribute to the project, please read the [contributing guidelines](https://github.com/Echlus/ivory/blob/main/CONTRIBUTING.md).
 
 ## 😸 About the project
-**Ivory** is a community driven project that aims to provide free and fast web APIs for everyone. Everyone can contribute to the project by adding new API's or fixing existing ones. The project is written in Typescrits and uses Nest.js and Qwik as the web framework. The project is currently in its early stages and we are working on adding more API's and improving the existing ones. If you want to contribute to the project, please read the [contributing guidelines](https://github.com/Echlus/ivory/blob/main/CONTRIBUTING.md).
+**Ivory** is a community driven project that aims to provide free and fast web APIs for everyone. Everyone can contribute to the project by adding new API's or fixing existing ones. The project is written in Typescrits and uses Nest.js and Qwik as the web framework. The project is currently in its early stages and we are working on adding more API's and improving the existing ones. See the contribution section.
   
 ## 🧩 Installation
 
@@ -17,6 +17,9 @@ cd ivory
 pnpm install # we only allow pnpm to install dependencies
 pnpm dev # to start the development server
 ```
+
+## 🛠️ Contribution
+Become the part of the project by making this repository better. Read more about the [Contributing Guidelines here](https://github.com/Echlus/ivory/blob/main/CONTRIBUTING.md).
 
 ## 📖 Documentation
 The documentation for the project is available at [Ivory Websites](https://ivory.ech.us). If you think that the documentation is missing something or is not clear enough, please open an issue or submit a pull request.


### PR DESCRIPTION
The contribution guidelines link is hard to see, so I moved to a new sub-heading instead to make it easy to spot